### PR TITLE
chore: remove comment referencing obsolete issue

### DIFF
--- a/src/srcmak.ts
+++ b/src/srcmak.ts
@@ -58,7 +58,6 @@ export async function srcmak(srcdir: string, options: Options = { }) {
       const target = path.join(options.golang.outdir, reldir);
       await fs.move(source, target, { overwrite: true });
       // remove go.mod as this would make it a submodule
-      // awaits https://github.com/aws/jsii/issues/2848
       await fs.remove(path.join(target, 'go.mod'));
     }
   });


### PR DESCRIPTION
The `go.mod` is an expected artifact from `jsii-pakmak` (https://github.com/aws/jsii/issues/2848#issuecomment-845408382).
So this is not awaiting an upstream change.

References:
* https://github.com/aws/jsii/issues/2848