### PR TITLE
fix: spawn JSII in shell reduces memory usage

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,7 @@ export async function exec(moduleName: string, args: string[] = [], options: Spa
     const opts: SpawnOptions = {
       ...options,
       stdio: ['inherit', 'pipe', 'pipe'],
+      shell: true,
     };
     const child = spawn(process.execPath, [moduleName, ...args], opts);
 


### PR DESCRIPTION
Fixes #579